### PR TITLE
CLI-9 # Fixed list-commands exiting before logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- CLI-8: Fixed commands exiting with incorrect code when errors are thrown
+- CLI-8: Commands exiting with incorrect code when errors are thrown
+
+- CLI-9: `bm list-commands` exiting before logging available commands 
 
 
 ## 1.1.3 - 2016-08-23

--- a/index.js
+++ b/index.js
@@ -37,14 +37,13 @@ const command = parsedArgs._[0];
 
 if (command === 'list-commands') {
   require('./commands/list-commands');
-  process.exit(0);
+} else {
+  exec(command)
+    .catch((err) => {
+      if (err && err.code === 'ENOENT') {
+        console.error(`Error: "${command}" is not an available ${cmd} command\n`);
+        showHelp();
+      }
+      process.exit(1);
+    });
 }
-
-exec(command)
-  .catch((err) => {
-    if (err && err.code === 'ENOENT') {
-      console.error(`Error: "${command}" is not an available ${cmd} command\n`);
-      showHelp();
-    }
-    process.exit(1);
-  });

--- a/index.js
+++ b/index.js
@@ -44,6 +44,6 @@ if (command === 'list-commands') {
         console.error(`Error: "${command}" is not an available ${cmd} command\n`);
         showHelp();
       }
-      process.exit(1);
+      process.exitCode = 1;
     });
 }


### PR DESCRIPTION
### Fixed

- CLI-9: `bm list-commands` exiting before logging available commands 