### PR TITLE
notify users if they are using wrong version or old version of Node.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": [
     "eslint:recommended",
+    "plugin:node/recommended",
     "semistandard"
   ],
   "env": {
@@ -9,5 +10,8 @@
   },
   "rules": {
     "no-console": 0
-  }
+  },
+  "plugins": [
+    "node"
+  ]
 }

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,2 +1,11 @@
 [ignore]
-.*/node_modules/\.cache/.*
+<PROJECT_ROOT>/.nyc_output/.*
+<PROJECT_ROOT>/build/.*
+<PROJECT_ROOT>/coverage/.*
+<PROJECT_ROOT>/dist/.*
+<PROJECT_ROOT>/node_modules/babel.*
+<PROJECT_ROOT>/node_modules/y18n/test/.*
+<PROJECT_ROOT>/node_modules/\.cache/.*
+
+[options]
+suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - '4'
   - '6'
+  - '7'
 sudo: false
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,32 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+
+## Unreleased
+
+
+### Added
+
+-   immediately stop execution if user's Node.js version doesn't match our package.json "engines"
+
+-   tell users (via [package-engines-notifier](https://github.com/jokeyrhyme/package-engines-notifier.js)) if their Node.js doesn't match our package.json "engines"
+
+  -   no message yet, as 4.x is our minimum, but there _will_ be a message if we increase this
+
+-   tell users (via [update-nodejs-notifier](https://github.com/jokeyrhyme/update-nodejs-notifier.js)) if the major version of their Node.js is older than the current stable
+
+  -   e.g. if users are on 4.x or 5.x, and 6.x  or 7.x available, then they will be notified
+
+  -   execution continues, this is just a warning
+
+
 ## 1.1.4 - 2016-10-17
 
 ### Fixed
 
 - CLI-8: Commands exiting with incorrect code when errors are thrown
 
-- CLI-9: `bm list-commands` exiting before logging available commands 
+- CLI-9: `bm list-commands` exiting before logging available commands
 
 
 ## 1.1.3 - 2016-08-23

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,11 +3,11 @@ environment:
   matrix:
     - nodejs_version: '4'
     - nodejs_version: '6'
+    - nodejs_version: '7'
 install:
-  - ps: 'Install-Product node $env:nodejs_version'
+  - ps: 'Install-Product node $env:nodejs_version x64'
   - npm install
 test_script:
   - node --version
   - npm --version
-  - npm cache clean
   - npm test

--- a/bin/index.js
+++ b/bin/index.js
@@ -2,14 +2,23 @@
 
 // foreign modules
 
+const enginesNotify = require('package-engines-notifier').enginesNotify;
+const updateNodejsNotifier = require('update-nodejs-notifier').updateNodejsNotifier;
 const updateNotifier = require('update-notifier');
 
 // local modules
 
-const pkg = require('./package.json');
+const pkg = require('../package.json');
 
 // this module
 
-updateNotifier({pkg}).notify();
+updateNotifier({ pkg: pkg }).notify();
 
-require('..');
+updateNodejsNotifier();
+
+if (!enginesNotify({ pkg: pkg })) {
+  // no engine trouble, proceed :)
+  require('..');
+} else {
+  process.exitCode = 1;
+}

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,3 +1,15 @@
 #!/usr/bin/env node
 
+// foreign modules
+
+const updateNotifier = require('update-notifier');
+
+// local modules
+
+const pkg = require('./package.json');
+
+// this module
+
+updateNotifier({pkg}).notify();
+
 require('..');

--- a/bin/index.js
+++ b/bin/index.js
@@ -14,7 +14,7 @@ const pkg = require('../package.json');
 
 updateNotifier({ pkg: pkg }).notify();
 
-updateNodejsNotifier();
+updateNodejsNotifier({ daysOld: 90 });
 
 if (!enginesNotify({ pkg: pkg })) {
   // no engine trouble, proceed :)

--- a/commands/list-commands.js
+++ b/commands/list-commands.js
@@ -22,5 +22,5 @@ list()
   })
   .catch((err) => {
     console.error(err);
-    process.exit(1);
+    process.exitCode = 1;
   });

--- a/index.js
+++ b/index.js
@@ -8,7 +8,6 @@ const path = require('path');
 
 const argvOne = require('argv-one');
 const parseArgs = require('minimist');
-const updateNotifier = require('update-notifier');
 
 // local modules
 
@@ -16,8 +15,6 @@ const exec = require('./lib/commands').exec;
 const pkg = require('./package.json');
 
 // this module
-
-updateNotifier({pkg}).notify();
 
 const cmd = path.basename(argvOne({ argv: process.argv, pkg }));
 

--- a/index.js
+++ b/index.js
@@ -27,20 +27,20 @@ function showHelp () {
 
 if (!parsedArgs._.length) {
   showHelp();
-  process.exit(0);
-}
-
-const command = parsedArgs._[0];
-
-if (command === 'list-commands') {
-  require('./commands/list-commands');
+  process.exitCode = 0;
 } else {
-  exec(command)
-    .catch((err) => {
-      if (err && err.code === 'ENOENT') {
-        console.error(`Error: "${command}" is not an available ${cmd} command\n`);
-        showHelp();
-      }
-      process.exitCode = 1;
-    });
+  const command = parsedArgs._[0];
+
+  if (command === 'list-commands') {
+    require('./commands/list-commands');
+  } else {
+    exec(command)
+      .catch((err) => {
+        if (err && err.code === 'ENOENT') {
+          console.error(`Error: "${command}" is not an available ${cmd} command\n`);
+          showHelp();
+        }
+        process.exitCode = 1;
+      });
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "graceful-fs": "4.1.9",
     "is-executable": "1.0.1",
     "minimist": "1.2.0",
-    "update-notifier": "^1.0.2"
+    "package-engines-notifier": "1.0.0",
+    "update-notifier": "1.0.2"
   },
   "devDependencies": {
     "ava": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "graceful-fs": "4.1.9",
     "is-executable": "1.0.1",
     "minimist": "1.2.0",
-    "package-engines-notifier": "1.0.0",
-    "update-nodejs-notifier": "1.0.1",
+    "package-engines-notifier": "1.1.0",
+    "update-nodejs-notifier": "1.1.0",
     "update-notifier": "1.0.2"
   },
   "devDependencies": {
@@ -28,7 +28,7 @@
     "eslint-plugin-promise": "^3.0.0",
     "eslint-plugin-standard": "^2.0.0",
     "fixpack": "^2.3.1",
-    "flow-bin": "^0.33.0",
+    "flow-bin": "^0.34.0",
     "greenkeeper-postpublish": "^1.0.0",
     "npm-bin-ava-tester": "^1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "is-executable": "1.0.1",
     "minimist": "1.2.0",
     "package-engines-notifier": "1.0.0",
+    "update-nodejs-notifier": "1.0.1",
     "update-notifier": "1.0.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@blinkmobile/cli",
   "description": "primary entry point for our CLI tools",
   "version": "1.1.4",
+  "author": "Ron Waldon <jokeyrhyme@gmail.com> (https://github.com/jokeyrhyme)",
   "bin": {
     "blinkm": "bin/index.js",
     "blinkm-list-commands": "bin/list-commands.js",
@@ -22,11 +23,12 @@
   },
   "devDependencies": {
     "ava": "^0.16.0",
-    "eslint": "^3.3.1",
+    "eslint": "^3.9.1",
     "eslint-config-semistandard": "^7.0.0",
-    "eslint-config-standard": "^6.0.0",
-    "eslint-plugin-promise": "^3.0.0",
-    "eslint-plugin-standard": "^2.0.0",
+    "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-node": "^3.0.0",
+    "eslint-plugin-promise": "^3.3.0",
+    "eslint-plugin-standard": "^2.0.1",
     "fixpack": "^2.3.1",
     "flow-bin": "^0.34.0",
     "greenkeeper-postpublish": "^1.0.0",
@@ -48,6 +50,7 @@
   "homepage": "https://github.com/blinkmobile/cli#readme",
   "keywords": [],
   "license": "BSD-3-Clause",
+  "main": "index.js",
   "publishConfig": {
     "access": "public"
   },
@@ -59,7 +62,7 @@
     "ava": "ava",
     "eslint": "eslint --fix --cache .",
     "fixpack": "fixpack",
-    "flow_check": "flow check || exit 0",
+    "flow_check": "flow check",
     "postpublish": "greenkeeper-postpublish",
     "posttest": "npm run eslint && npm run flow_check && npm run fixpack",
     "test": "npm run ava"

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": [
+    "../.eslintrc.json"
+  ],
+  "rules": {
+    "node/no-unpublished-require": 0,
+    "node/no-unsupported-features": 0
+  }
+}


### PR DESCRIPTION
### Added
-   immediately stop execution if user's Node.js version doesn't match our package.json "engines"
-   tell users (via [package-engines-notifier](https://github.com/jokeyrhyme/package-engines-notifier.js)) if their Node.js doesn't match our package.json "engines"
  -   no message yet, as 4.x is our minimum, but there _will_ be a message if we increase this
-   tell users (via [update-nodejs-notifier](https://github.com/jokeyrhyme/update-nodejs-notifier.js)) if the major version of their Node.js is older than the current stable
  -   e.g. if users are on 4.x or 5.x, and 6.x  or 7.x available, then they will be notified
  -   execution continues, this is just a warning
### Notes
- users on 5.x or lower will see something like this (today):

> Node.js update available v5.12.0 → v6.9.1
> v5.12.0 is older than the latest stable version
- when I temporarily make 5.x our minimum, users on 4.x see this as well right before execution stops:

> @blinkmobile/cli requires node >=5.0.0
> current node version is v4.6.1
